### PR TITLE
API 응답 포맷 설정

### DIFF
--- a/src/main/java/net/mediger/auth/api/AuthController.java
+++ b/src/main/java/net/mediger/auth/api/AuthController.java
@@ -1,55 +1,57 @@
 package net.mediger.auth.api;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import net.mediger.auth.api.docs.AuthApiDocs;
 import net.mediger.auth.api.dto.RequestBusinessJoin;
 import net.mediger.auth.api.dto.RequestJoin;
 import net.mediger.auth.api.dto.RequestLogin;
 import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.auth.service.AuthService;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
+import net.mediger.global.exception.response.ApiResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Auth Controller", description = "회원가입/로그인 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/auth")
-public class AuthController {
+public class AuthController implements AuthApiDocs {
 
     private final AuthService authService;
 
-    @PostMapping("check/{account}")
-    public ResponseEntity<Boolean> checkAccount(@PathVariable String account) {
-        return ResponseEntity.ok(authService.isCheckedAccount(account));
+    @Override
+    @PostMapping("check")
+    public ApiResponse<Boolean> checkAccount(@RequestParam String account) {
+        return ApiResponse.success(authService.isCheckedAccount(account));
     }
 
+    @Override
     @PostMapping("join")
-    public ResponseEntity<Void> join(@RequestBody RequestJoin requestJoin) {
+    public ApiResponse<Void> join(@RequestBody RequestJoin requestJoin) {
         authService.join(requestJoin);
 
-        return ResponseEntity.status(CREATED).build();
+        return ApiResponse.successWithNoContent();
     }
 
+    @Override
     @PostMapping("join/business")
-    public ResponseEntity<Void> joinBusiness(@RequestBody RequestBusinessJoin requestBusinessJoin) {
+    public ApiResponse<Void> joinBusiness(@RequestBody RequestBusinessJoin requestBusinessJoin) {
         authService.joinBusiness(requestBusinessJoin);
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.successWithNoContent();
     }
 
+    @Override
     @PostMapping("login")
-    public ResponseEntity<ResponseToken> login(@RequestBody RequestLogin requestLogin) {
-        return ResponseEntity.ok(authService.login(requestLogin));
+    public ApiResponse<ResponseToken> login(@RequestBody RequestLogin requestLogin) {
+        return ApiResponse.success(authService.login(requestLogin));
     }
 
+    @Override
     @PostMapping("login/business")
-    public ResponseEntity<ResponseToken> loginBusiness(@RequestBody RequestLogin requestLogin) {
-        return ResponseEntity.ok(authService.loginBusiness(requestLogin));
+    public ApiResponse<ResponseToken> loginBusiness(@RequestBody RequestLogin requestLogin) {
+        return ApiResponse.success(authService.loginBusiness(requestLogin));
     }
 }

--- a/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
+++ b/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
@@ -1,0 +1,49 @@
+package net.mediger.auth.api.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import net.mediger.auth.api.dto.RequestBusinessJoin;
+import net.mediger.auth.api.dto.RequestJoin;
+import net.mediger.auth.api.dto.RequestLogin;
+import net.mediger.auth.jwt.ResponseToken;
+import net.mediger.global.exception.response.ApiResponse;
+
+@Tag(name = "Auth Controller", description = "회원가입/로그인 API")
+public interface AuthApiDocs {
+
+    @Operation(summary = "아이디 중복 확인")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "아이디 중복 X"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "아이디 중복 O")}
+    )
+    ApiResponse<Boolean> checkAccount(String account);
+
+    @Operation(summary = "일반 회원 가입")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 오류")
+    })
+    ApiResponse<Void> join(RequestJoin requestJoin);
+
+    @Operation(summary = "사업자 회원 가입")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 오류")
+    })
+    ApiResponse<Void> joinBusiness(RequestBusinessJoin requestBusinessJoin);
+
+    @Operation(summary = "일반 회원 로그인")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "로그인 실패")}
+    )
+    ApiResponse<ResponseToken> login(RequestLogin requestLogin);
+
+    @Operation(summary = "사업자 회원 로그인")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "로그인 실패")}
+    )
+    ApiResponse<ResponseToken> loginBusiness(RequestLogin requestLogin);
+}

--- a/src/main/java/net/mediger/auth/api/dto/RequestBusinessJoin.java
+++ b/src/main/java/net/mediger/auth/api/dto/RequestBusinessJoin.java
@@ -5,6 +5,8 @@ import static net.mediger.auth.api.dto.JoinRegex.EMAIL_REGEX;
 import static net.mediger.auth.api.dto.JoinRegex.PASSWORD_REGEX;
 
 import java.time.LocalDate;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
 
 public record RequestBusinessJoin(
         String account,
@@ -30,34 +32,34 @@ public record RequestBusinessJoin(
 
     private void validateAccount(String account) {
         if (account == null || account.isBlank()) {
-            throw new IllegalArgumentException("아이디는 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_ACCOUNT);
         }
         if (!ACCOUNT_REGEX.matcher(account).matches()) {
-            throw new IllegalArgumentException("아이디의 형식이 올바르지 않습니다. (영문 8자 이상)");
+            throw new CustomException(ErrorCode.INVALID_ACCOUNT);
         }
     }
 
     private void validatePassword(String password) {
         if (password == null || password.isBlank()) {
-            throw new IllegalArgumentException("비밀번호는 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_PASSWORD);
         }
         if (!PASSWORD_REGEX.matcher(password).matches()) {
-            throw new IllegalArgumentException("비밀번호의 형식이 올바르지 않습니다. (대/소문자와 특수문자 포함 8자 이상)");
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
     }
 
     private void validateName(String name) {
         if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("이름은 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_NAME);
         }
     }
 
     private void validateEmail(String email) {
         if (email == null || email.isBlank()) {
-            throw new IllegalArgumentException("이메일은 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_EMAIL);
         }
         if (!EMAIL_REGEX.matcher(email).matches()) {
-            throw new IllegalArgumentException("이메일 형식(xxx@xxx.xx)이 올바르지 않습니다.");
+            throw new CustomException(ErrorCode.INVALID_EMAIL);
         }
     }
 }

--- a/src/main/java/net/mediger/auth/api/dto/RequestJoin.java
+++ b/src/main/java/net/mediger/auth/api/dto/RequestJoin.java
@@ -5,6 +5,9 @@ import static net.mediger.auth.api.dto.JoinRegex.EMAIL_REGEX;
 import static net.mediger.auth.api.dto.JoinRegex.PASSWORD_REGEX;
 import static net.mediger.auth.api.dto.JoinRegex.PHONE_REGEX;
 
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
+
 public record RequestJoin(
         String account,
         String password,
@@ -27,43 +30,43 @@ public record RequestJoin(
 
     private void validateAccount(String account) {
         if (account == null || account.isBlank()) {
-            throw new IllegalArgumentException("아이디는 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_ACCOUNT);
         }
         if (!ACCOUNT_REGEX.matcher(account).matches()) {
-            throw new IllegalArgumentException("아이디의 형식이 올바르지 않습니다. (영문 8자 이상)");
+            throw new CustomException(ErrorCode.INVALID_ACCOUNT);
         }
     }
 
     private void validatePassword(String password) {
         if (password == null || password.isBlank()) {
-            throw new IllegalArgumentException("비밀번호는 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_PASSWORD);
         }
         if (!PASSWORD_REGEX.matcher(password).matches()) {
-            throw new IllegalArgumentException("비밀번호의 형식이 올바르지 않습니다. (대/소문자와 특수문자 포함 8자 이상)");
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
     }
 
     private void validateName(String name) {
         if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("이름은 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_NAME);
         }
     }
 
     private void validateEmail(String email) {
         if (email == null || email.isBlank()) {
-            throw new IllegalArgumentException("이메일은 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_EMAIL);
         }
         if (!EMAIL_REGEX.matcher(email).matches()) {
-            throw new IllegalArgumentException("이메일 형식(xxx@xxx.xx)이 올바르지 않습니다.");
+            throw new CustomException(ErrorCode.INVALID_EMAIL);
         }
     }
 
     private void validatePhone(String phone) {
         if (phone == null || phone.isBlank()) {
-            throw new IllegalArgumentException("휴대폰 번호는 필수로 입력해야 합니다.");
+            throw new CustomException(ErrorCode.NULL_PHONE);
         }
         if (!PHONE_REGEX.matcher(phone).matches()) {
-            throw new IllegalArgumentException("휴대폰 형식이 올바르지 않습니다. (하이픈 없이)");
+            throw new CustomException(ErrorCode.INVALID_PHONE);
         }
     }
 }

--- a/src/main/java/net/mediger/auth/jwt/TokenProvider.java
+++ b/src/main/java/net/mediger/auth/jwt/TokenProvider.java
@@ -8,6 +8,8 @@ import java.util.Date;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
 import net.mediger.global.properties.JwtProperties;
 import net.mediger.auth.jwt.redis.RedisService;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -62,9 +64,9 @@ public class TokenProvider {
                     .get(key)
                     .toString();
         } catch (ExpiredJwtException e) {
-            throw new IllegalArgumentException("만료된 토큰입니다.", e.getCause());
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         } catch (Exception e) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.", e.getCause());
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/net/mediger/global/config/SecurityConfig.java
+++ b/src/main/java/net/mediger/global/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 
 import lombok.RequiredArgsConstructor;
 import net.mediger.auth.jwt.JwtFilter;
+import net.mediger.global.exception.handler.GlobalAccessDeniedHandler;
+import net.mediger.global.exception.handler.GlobalAuthenticationEntryPoint;
 import net.mediger.global.properties.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +26,8 @@ public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
     private final SecurityProperties securityProperties;
+    private final GlobalAuthenticationEntryPoint globalAuthenticationEntryPoint;
+    private final GlobalAccessDeniedHandler globalAccessDeniedHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -42,6 +46,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         auth -> auth.requestMatchers(securityProperties.getWhiteListMatchers()).permitAll()
                                 .anyRequest().authenticated())
+                .exceptionHandling(
+                        exception -> exception.authenticationEntryPoint(globalAuthenticationEntryPoint)
+                                .accessDeniedHandler(globalAccessDeniedHandler))
+
                 .build();
     }
 }

--- a/src/main/java/net/mediger/global/exception/CustomException.java
+++ b/src/main/java/net/mediger/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package net.mediger.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/net/mediger/global/exception/ErrorCode.java
+++ b/src/main/java/net/mediger/global/exception/ErrorCode.java
@@ -1,0 +1,42 @@
+package net.mediger.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
+    NULL_ACCOUNT(HttpStatus.BAD_REQUEST, "아이디는 필수로 입력해야 합니다."),
+    INVALID_ACCOUNT(HttpStatus.BAD_REQUEST, "아이디의 형식이 올바르지 않습니다. (영문 8자 이상)"),
+
+    NULL_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 필수로 입력해야 합니다."),
+    MISMATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호의 형식이 올바르지 않습니다. (영문, 숫자, 특수문자 8자 이상)"),
+
+    NULL_NAME(HttpStatus.BAD_REQUEST, "이름은 필수로 입력해야 합니다."),
+
+    NULL_EMAIL(HttpStatus.BAD_REQUEST, "이메일은 필수로 입력해야 합니다."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "이메일 형식(xxx@xxx.xx)이 올바르지 않습니다."),
+
+    NULL_PHONE(HttpStatus.BAD_REQUEST, "휴대폰 번호는 필수로 입력해야 합니다."),
+    INVALID_PHONE(HttpStatus.BAD_REQUEST, "휴대폰 번호의 형식(010xxxxxxxx)이 올바르지 않습니다."),
+
+    NOT_MATCH_USER(HttpStatus.BAD_REQUEST, "본인의 정보만 수정할 수 있습니다."),
+
+    NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 아이디입니다."),
+    NOT_FOUND_AGE_RANGE(HttpStatus.NOT_FOUND, "존재하지 않는 연령대 입니다."),
+    NOT_FOUND_HEALTH_CONDITIONS(HttpStatus.NOT_FOUND, "존재하지 않는 건강 상태 입니다."),
+    NOT_FOUND_GENDER(HttpStatus.NOT_FOUND, "존재하지 않는 성별 입니다."),
+
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/net/mediger/global/exception/handler/GlobalAccessDeniedHandler.java
+++ b/src/main/java/net/mediger/global/exception/handler/GlobalAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package net.mediger.global.exception.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import net.mediger.global.exception.ErrorCode;
+import net.mediger.global.exception.response.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GlobalAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter()
+                .write(new ObjectMapper().writeValueAsString(ApiResponse.error(ErrorCode.ACCESS_DENIED)));
+    }
+}

--- a/src/main/java/net/mediger/global/exception/handler/GlobalAuthenticationEntryPoint.java
+++ b/src/main/java/net/mediger/global/exception/handler/GlobalAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package net.mediger.global.exception.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import net.mediger.global.exception.ErrorCode;
+import net.mediger.global.exception.response.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GlobalAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write(new ObjectMapper().writeValueAsString(ApiResponse.error(ErrorCode.UNAUTHORIZED)));
+    }
+}

--- a/src/main/java/net/mediger/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/net/mediger/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package net.mediger.global.exception.handler;
+
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.error(e.getErrorCode()));
+    }
+}

--- a/src/main/java/net/mediger/global/exception/response/ApiResponse.java
+++ b/src/main/java/net/mediger/global/exception/response/ApiResponse.java
@@ -1,0 +1,31 @@
+package net.mediger.global.exception.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.mediger.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private HttpStatus status;
+    private int code;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(HttpStatus.OK, HttpStatus.OK.value(), null, data);
+    }
+
+    public static ApiResponse<Void> successWithNoContent() {
+        return new ApiResponse<>(HttpStatus.NO_CONTENT, HttpStatus.NO_CONTENT.value(), null, null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getStatus(), errorCode.getStatus().value(), errorCode.getMessage(), null);
+    }
+}

--- a/src/main/java/net/mediger/member/api/MemberController.java
+++ b/src/main/java/net/mediger/member/api/MemberController.java
@@ -1,47 +1,50 @@
 package net.mediger.member.api;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
+import net.mediger.global.exception.response.ApiResponse;
+import net.mediger.member.api.docs.MemberApiDocs;
 import net.mediger.member.api.dto.RequestBusinessDetails;
 import net.mediger.member.api.dto.RequestDetails;
 import net.mediger.member.service.MemberService;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Member Controller", description = "회원 관련 API")
 @RestController
 @RequestMapping("api/member")
 @RequiredArgsConstructor
-public class MemberController {
+public class MemberController implements MemberApiDocs {
 
     private final MemberService memberService;
 
+    @Override
     @PatchMapping("/{id}")
-    public ResponseEntity<Void> update(Principal principal, @PathVariable Long id,
-                                       @RequestBody RequestDetails requestDetails) {
+    public ApiResponse<Void> update(Principal principal, @PathVariable Long id,
+                                    @RequestBody RequestDetails requestDetails) {
         checkOwner(principal, id);
         memberService.updateDetails(id, requestDetails);
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.successWithNoContent();
     }
 
+    @Override
     @PatchMapping("business/{id}")
-    public ResponseEntity<Void> updateBusiness(Principal principal, @PathVariable Long id,
-                                               @RequestBody RequestBusinessDetails requestDetails) {
+    public ApiResponse<Void> updateBusiness(Principal principal, @PathVariable Long id,
+                                            @RequestBody RequestBusinessDetails requestDetails) {
         checkOwner(principal, id);
         memberService.updateBusinessDetails(id, requestDetails);
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.successWithNoContent();
     }
 
     private void checkOwner(Principal principal, Long id) {
         if (!principal.getName().equals(String.valueOf(id))) {
-            throw new IllegalArgumentException("본인의 정보만 수정할 수 있습니다.");
+            throw new CustomException(ErrorCode.NOT_MATCH_USER);
         }
     }
 }

--- a/src/main/java/net/mediger/member/api/docs/MemberApiDocs.java
+++ b/src/main/java/net/mediger/member/api/docs/MemberApiDocs.java
@@ -1,0 +1,27 @@
+package net.mediger.member.api.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
+import net.mediger.global.exception.response.ApiResponse;
+import net.mediger.member.api.dto.RequestBusinessDetails;
+import net.mediger.member.api.dto.RequestDetails;
+
+@Tag(name = "Member Controller", description = "회원 관련 API")
+public interface MemberApiDocs {
+
+    @Operation(summary = "회원 정보 업데이트")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "회원 정보 업데이트 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "회원 정보 업데이트 실패")}
+    )
+    ApiResponse<Void> update(Principal principal, Long id, RequestDetails requestDetails);
+
+    @Operation(summary = "사업자 정보 업데이트")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "사업자 정보 업데이트 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "사업자 정보 업데이트 실패")}
+    )
+    ApiResponse<Void> updateBusiness(Principal principal, Long id, RequestBusinessDetails requestBusinessDetails);
+}

--- a/src/main/java/net/mediger/member/api/dto/RequestDetails.java
+++ b/src/main/java/net/mediger/member/api/dto/RequestDetails.java
@@ -1,6 +1,8 @@
 package net.mediger.member.api.dto;
 
 import java.util.List;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
 
 public record RequestDetails(
         String gender,
@@ -14,7 +16,7 @@ public record RequestDetails(
 
     private void validateAge(int age) {
         if (age < 10) {
-            throw new IllegalArgumentException("나이는 10세 이상이어야 합니다.");
+            throw new CustomException(ErrorCode.NOT_FOUND_AGE_RANGE);
         }
     }
 }

--- a/src/main/java/net/mediger/member/domain/AgeRange.java
+++ b/src/main/java/net/mediger/member/domain/AgeRange.java
@@ -1,5 +1,10 @@
 package net.mediger.member.domain;
 
+import lombok.Getter;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
+
+@Getter
 public enum AgeRange {
 
     TEENAGER(10),
@@ -31,7 +36,7 @@ public enum AgeRange {
             case 80 -> EIGHTIES;
             case 90 -> NINETIES;
             case 100 -> CENTENARIAN;
-            default -> throw new IllegalArgumentException("존재하지 않는 연령대입니다.");
+            default -> throw new CustomException(ErrorCode.NOT_FOUND_AGE_RANGE);
         };
     }
 }

--- a/src/main/java/net/mediger/member/domain/Gender.java
+++ b/src/main/java/net/mediger/member/domain/Gender.java
@@ -1,6 +1,8 @@
 package net.mediger.member.domain;
 
 import java.util.Arrays;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
 
 public enum Gender {
 
@@ -10,6 +12,6 @@ public enum Gender {
         return Arrays.stream(Gender.values())
                 .filter(gen -> gen.toString().equals(gender.toUpperCase()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성별입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GENDER));
     }
 }

--- a/src/main/java/net/mediger/member/domain/HealthConditions.java
+++ b/src/main/java/net/mediger/member/domain/HealthConditions.java
@@ -1,10 +1,14 @@
 package net.mediger.member.domain;
 
 import java.util.List;
+import lombok.Getter;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
 
+@Getter
 public enum HealthConditions {
 
-    ESSENTIAL("필수건강"),
+    ESSENTIAL("필수 건강"),
     ENERGY("에너지"),
     STRONG_IMMUNITY("면역 튼튼"),
     HAIR_GROWTH("모발 쑥쑥"),
@@ -31,20 +35,20 @@ public enum HealthConditions {
             return switch (condition) {
                 case "필수건강" -> ESSENTIAL;
                 case "에너지" -> ENERGY;
-                case "면역 튼튼" -> STRONG_IMMUNITY;
-                case "모발 쑥쑥" -> HAIR_GROWTH;
+                case "면역튼튼" -> STRONG_IMMUNITY;
+                case "모발쑥쑥" -> HAIR_GROWTH;
                 case "꿀잠" -> GOOD_SLEEP;
-                case "월경 전 불편" -> MENSTRUAL_DISCOMFORT;
-                case "뼈 진단" -> BONE_DIAGNOSIS;
+                case "월경전불편" -> MENSTRUAL_DISCOMFORT;
+                case "뼈진단" -> BONE_DIAGNOSIS;
                 case "애주가" -> KIDNEY;
-                case "혈관 튼튼" -> BLOOD_VESSELS;
-                case "혈당 관리" -> BLOOD_SUGAR;
-                case "편한 소화" -> DIGESTION;
+                case "혈관튼튼" -> BLOOD_VESSELS;
+                case "혈당관리" -> BLOOD_SUGAR;
+                case "편한소화" -> DIGESTION;
                 case "다이어트" -> DIET;
-                case "피부 미용" -> SKIN_CARE;
+                case "피부미용" -> SKIN_CARE;
                 case "집중" -> FOCUS;
-                case "수험생 건강" -> EXAMINEE;
-                default -> throw new IllegalArgumentException("존재하지 않는 건강조건입니다.");
+                case "수험생건강" -> EXAMINEE;
+                default -> throw new CustomException(ErrorCode.NOT_FOUND_HEALTH_CONDITIONS);
             };
         }
         return null;

--- a/src/main/java/net/mediger/member/repository/BusinessRepository.java
+++ b/src/main/java/net/mediger/member/repository/BusinessRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BusinessRepository extends JpaRepository<Business, Long> {
+    boolean existsByAccount(String account);
     Optional<Business> findBusinessByAccount(String account);
 }

--- a/src/main/java/net/mediger/member/service/MemberService.java
+++ b/src/main/java/net/mediger/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package net.mediger.member.service;
 
 import lombok.RequiredArgsConstructor;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
 import net.mediger.member.api.dto.RequestBusinessDetails;
 import net.mediger.member.api.dto.RequestDetails;
 import net.mediger.member.domain.AgeRange;
@@ -39,11 +41,11 @@ public class MemberService {
 
     private Member findAccount(Long id) {
         return memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ACCOUNT));
     }
 
     private Business findBusinessAccount(Long id) {
         return businessRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기업 아이디입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ACCOUNT));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     database: mysql
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/net/mediger/api/member/domain/GenderTest.java
+++ b/src/test/java/net/mediger/api/member/domain/GenderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import net.mediger.global.exception.CustomException;
 import net.mediger.member.domain.Gender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,6 +36,6 @@ class GenderTest {
     @ValueSource(strings = {"남성", "여성", "기타"})
     void shouldThrowException_WhenInvalidGender(String invalidGender) {
         assertThatThrownBy(() -> Gender.findGender(invalidGender))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(CustomException.class);
     }
 }


### PR DESCRIPTION
## 내용
- #16 
- 일관된 포맷으로 응답합니다.

### 성공 시
```json
{
  "status": "OK",
  "code": 200,
  "message": null,
  "data": true
}
```

### 예외 발생 시
```json
{
  "status": "BAD_REQUEST",
  "code": 400,
  "message": "아이디의 형식이 올바르지 않습니다. (영문 8자 이상)",
  "data": null
}
```

Spring Security 예외 발생 시에도 `AuthenticationEntryPoint`와 `AccessDeniedHandler`를 구현하여 일관된 포맷으로 응답하게 하였습니다.