### PR TITLE
휴대폰 & 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'net.nurigo:sdk:4.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'net.nurigo:sdk:4.3.2'
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/net/mediger/auth/api/AuthController.java
+++ b/src/main/java/net/mediger/auth/api/AuthController.java
@@ -5,6 +5,7 @@ import net.mediger.auth.api.docs.AuthApiDocs;
 import net.mediger.auth.api.dto.RequestBusinessJoin;
 import net.mediger.auth.api.dto.RequestJoin;
 import net.mediger.auth.api.dto.RequestLogin;
+import net.mediger.auth.api.dto.RequestVerify;
 import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.auth.service.AuthService;
 import net.mediger.global.exception.response.ApiResponse;
@@ -25,6 +26,20 @@ public class AuthController implements AuthApiDocs {
     @PostMapping("check")
     public ApiResponse<Boolean> checkAccount(@RequestParam String account) {
         return ApiResponse.success(authService.isCheckedAccount(account));
+    }
+
+    @Override
+    @PostMapping("certification")
+    public ApiResponse<Void> certification(@RequestParam String phone) {
+        authService.certification(phone);
+
+        return ApiResponse.successWithNoContent();
+    }
+
+    @Override
+    @PostMapping("verify")
+    public ApiResponse<Boolean> verify(@RequestBody RequestVerify requestVerify) {
+        return ApiResponse.success(authService.verify(requestVerify.phone(), requestVerify.code()));
     }
 
     @Override

--- a/src/main/java/net/mediger/auth/api/AuthController.java
+++ b/src/main/java/net/mediger/auth/api/AuthController.java
@@ -40,9 +40,17 @@ public class AuthController implements AuthApiDocs {
     }
 
     @Override
+    @PostMapping("certification/business")
+    public ApiResponse<Void> certificationBusiness(@RequestParam String email) {
+        authService.certificationBusiness(email);
+
+        return ApiResponse.success(HttpStatus.NO_CONTENT);
+    }
+
+    @Override
     @PostMapping("verify")
     public ApiResponse<Boolean> verify(@RequestBody RequestVerify requestVerify) {
-        return ApiResponse.success(authService.verify(requestVerify.phone(), requestVerify.code()));
+        return ApiResponse.success(authService.verify(requestVerify.identifier(), requestVerify.code()));
     }
 
     @Override

--- a/src/main/java/net/mediger/auth/api/AuthController.java
+++ b/src/main/java/net/mediger/auth/api/AuthController.java
@@ -1,5 +1,6 @@
 package net.mediger.auth.api;
 
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import net.mediger.auth.api.docs.AuthApiDocs;
 import net.mediger.auth.api.dto.RequestBusinessJoin;
@@ -9,6 +10,8 @@ import net.mediger.auth.api.dto.RequestVerify;
 import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.auth.service.AuthService;
 import net.mediger.global.exception.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,7 +36,7 @@ public class AuthController implements AuthApiDocs {
     public ApiResponse<Void> certification(@RequestParam String phone) {
         authService.certification(phone);
 
-        return ApiResponse.successWithNoContent();
+        return ApiResponse.success(HttpStatus.NO_CONTENT);
     }
 
     @Override
@@ -44,18 +47,24 @@ public class AuthController implements AuthApiDocs {
 
     @Override
     @PostMapping("join")
-    public ApiResponse<Void> join(@RequestBody RequestJoin requestJoin) {
-        authService.join(requestJoin);
+    public ResponseEntity<ApiResponse<Void>> join(@RequestBody RequestJoin requestJoin) {
+        Long memberId = authService.join(requestJoin);
 
-        return ApiResponse.successWithNoContent();
+        URI location = URI.create("/api/member/" + memberId);
+
+        return ResponseEntity.created(location)
+                .body(ApiResponse.success(HttpStatus.CREATED));
     }
 
     @Override
     @PostMapping("join/business")
-    public ApiResponse<Void> joinBusiness(@RequestBody RequestBusinessJoin requestBusinessJoin) {
-        authService.joinBusiness(requestBusinessJoin);
+    public ResponseEntity<ApiResponse<Void>> joinBusiness(@RequestBody RequestBusinessJoin requestBusinessJoin) {
+        Long businessId = authService.joinBusiness(requestBusinessJoin);
 
-        return ApiResponse.successWithNoContent();
+        URI location = URI.create("/api/member/business/" + businessId);
+
+        return ResponseEntity.created(location)
+                .body(ApiResponse.success(HttpStatus.CREATED));
     }
 
     @Override

--- a/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
+++ b/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
@@ -6,8 +6,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import net.mediger.auth.api.dto.RequestBusinessJoin;
 import net.mediger.auth.api.dto.RequestJoin;
 import net.mediger.auth.api.dto.RequestLogin;
+import net.mediger.auth.api.dto.RequestVerify;
 import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.global.exception.response.ApiResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Auth Controller", description = "회원가입/로그인 API")
 public interface AuthApiDocs {
@@ -18,6 +22,21 @@ public interface AuthApiDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "아이디 중복 O")}
     )
     ApiResponse<Boolean> checkAccount(String account);
+
+
+    @Operation(summary = "휴대폰 인증")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "인증번호 전송 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "인증번호 전송 실패")}
+    )
+    ApiResponse<Void> certification(@RequestParam String phone);
+
+    @Operation(summary = "휴대폰 인증 확인")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "인증 실패")}
+    )
+    ApiResponse<Boolean> verify(@RequestBody RequestVerify requestVerify);
 
     @Operation(summary = "일반 회원 가입")
     @ApiResponses(value = {

--- a/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
+++ b/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
@@ -9,7 +9,7 @@ import net.mediger.auth.api.dto.RequestLogin;
 import net.mediger.auth.api.dto.RequestVerify;
 import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.global.exception.response.ApiResponse;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -40,17 +40,17 @@ public interface AuthApiDocs {
 
     @Operation(summary = "일반 회원 가입")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 오류")
     })
-    ApiResponse<Void> join(RequestJoin requestJoin);
+    ResponseEntity<ApiResponse<Void>> join(RequestJoin requestJoin);
 
     @Operation(summary = "사업자 회원 가입")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 오류")
     })
-    ApiResponse<Void> joinBusiness(RequestBusinessJoin requestBusinessJoin);
+    ResponseEntity<ApiResponse<Void>> joinBusiness(RequestBusinessJoin requestBusinessJoin);
 
     @Operation(summary = "일반 회원 로그인")
     @ApiResponses(value = {

--- a/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
+++ b/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
@@ -10,8 +10,6 @@ import net.mediger.auth.api.dto.RequestVerify;
 import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.global.exception.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Auth Controller", description = "회원가입/로그인 API")
 public interface AuthApiDocs {
@@ -23,20 +21,26 @@ public interface AuthApiDocs {
     )
     ApiResponse<Boolean> checkAccount(String account);
 
-
     @Operation(summary = "휴대폰 인증")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "인증번호 전송 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "인증번호 전송 실패")}
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "인증번호 전송 실패")}
     )
-    ApiResponse<Void> certification(@RequestParam String phone);
+    ApiResponse<Void> certification(String phone);
 
-    @Operation(summary = "휴대폰 인증 확인")
+    @Operation(summary = "이메일 인증")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "인증번호 전송 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "인증번호 전송 실패")}
+    )
+    ApiResponse<Void> certificationBusiness(String email);
+
+    @Operation(summary = "휴대폰 / 이메일 인증 확인")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "인증 실패")}
     )
-    ApiResponse<Boolean> verify(@RequestBody RequestVerify requestVerify);
+    ApiResponse<Boolean> verify(RequestVerify requestVerify);
 
     @Operation(summary = "일반 회원 가입")
     @ApiResponses(value = {

--- a/src/main/java/net/mediger/auth/api/dto/RequestBusinessJoin.java
+++ b/src/main/java/net/mediger/auth/api/dto/RequestBusinessJoin.java
@@ -4,7 +4,6 @@ import static net.mediger.auth.api.dto.JoinRegex.ACCOUNT_REGEX;
 import static net.mediger.auth.api.dto.JoinRegex.EMAIL_REGEX;
 import static net.mediger.auth.api.dto.JoinRegex.PASSWORD_REGEX;
 
-import java.time.LocalDate;
 import net.mediger.global.exception.CustomException;
 import net.mediger.global.exception.ErrorCode;
 
@@ -14,7 +13,7 @@ public record RequestBusinessJoin(
         String name,
         String email,
         String registrationNumber,
-        LocalDate startDate,
+        String startDate,
         String ownerName,
         String companyName
 ) {

--- a/src/main/java/net/mediger/auth/api/dto/RequestVerify.java
+++ b/src/main/java/net/mediger/auth/api/dto/RequestVerify.java
@@ -1,7 +1,7 @@
 package net.mediger.auth.api.dto;
 
 public record RequestVerify(
-        String phone,
+        String identifier,
         String code
 ) {
 }

--- a/src/main/java/net/mediger/auth/api/dto/RequestVerify.java
+++ b/src/main/java/net/mediger/auth/api/dto/RequestVerify.java
@@ -1,0 +1,7 @@
+package net.mediger.auth.api.dto;
+
+public record RequestVerify(
+        String phone,
+        String code
+) {
+}

--- a/src/main/java/net/mediger/auth/jwt/redis/RedisService.java
+++ b/src/main/java/net/mediger/auth/jwt/redis/RedisService.java
@@ -31,9 +31,9 @@ public class RedisService {
         redisRepository.deleteById(tokenId);
     }
 
-    public void saveCertificationCode(String phone, String code) {
+    public void saveCertificationCode(String identifier, String code) {
         try {
-            String key = CERTIFICATION_PREFIX + phone;
+            String key = CERTIFICATION_PREFIX + identifier;
             redisTemplate.opsForValue().set(key, code, Duration.ofMinutes(3));
             log.info("\uD83D\uDFE2 인증번호 저장 완료: {}", key);
         } catch (Exception e) {
@@ -41,13 +41,13 @@ public class RedisService {
         }
     }
 
-    public String getCertificationCode(String phone) {
-        String key = CERTIFICATION_PREFIX + phone;
+    public String getCertificationCode(String identifier) {
+        String key = CERTIFICATION_PREFIX + identifier;
         return redisTemplate.opsForValue().get(key);
     }
 
-    public void deleteCertificationCode(String phone) {
-        String key = CERTIFICATION_PREFIX + phone;
+    public void deleteCertificationCode(String identifier) {
+        String key = CERTIFICATION_PREFIX + identifier;
         redisTemplate.delete(key);
     }
 }

--- a/src/main/java/net/mediger/auth/jwt/redis/RedisService.java
+++ b/src/main/java/net/mediger/auth/jwt/redis/RedisService.java
@@ -1,7 +1,9 @@
 package net.mediger.auth.jwt.redis;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -9,7 +11,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RedisService {
 
+    private static final String CERTIFICATION_PREFIX = "certification:";
+
     private final RedisRepository redisRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public void saveRefreshToken(String tokenId, Long memberId) {
         try {
@@ -24,5 +29,25 @@ public class RedisService {
 
     public void deleteRefreshToken(String tokenId) {
         redisRepository.deleteById(tokenId);
+    }
+
+    public void saveCertificationCode(String phone, String code) {
+        try {
+            String key = CERTIFICATION_PREFIX + phone;
+            redisTemplate.opsForValue().set(key, code, Duration.ofMinutes(3));
+            log.info("\uD83D\uDFE2 인증번호 저장 완료: {}", key);
+        } catch (Exception e) {
+            log.error("\uD83D\uDFE2 인증번호 저장 실패: {}", e.getMessage());
+        }
+    }
+
+    public String getCertificationCode(String phone) {
+        String key = CERTIFICATION_PREFIX + phone;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteCertificationCode(String phone) {
+        String key = CERTIFICATION_PREFIX + phone;
+        redisTemplate.delete(key);
     }
 }

--- a/src/main/java/net/mediger/auth/service/AuthService.java
+++ b/src/main/java/net/mediger/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.auth.jwt.TokenProvider;
 import net.mediger.global.exception.CustomException;
 import net.mediger.global.exception.ErrorCode;
+import net.mediger.global.message.MailMessageSender;
 import net.mediger.global.message.SMSMessageSender;
 import net.mediger.member.domain.Business;
 import net.mediger.member.domain.Member;
@@ -28,6 +29,7 @@ public class AuthService {
     private final BusinessRepository businessRepository;
     private final CertificationCodeService certificationCodeService;
     private final SMSMessageSender smsMessageSender;
+    private final MailMessageSender mailMessageSender;
 
     @Transactional
     public boolean isCheckedAccount(String account) {
@@ -44,17 +46,22 @@ public class AuthService {
 
     public void certification(String phone) {
         String code = certificationCodeService.generateCertificationCode(phone);
-        smsMessageSender.send(phone, "Mediger 인증번호", code);
+        smsMessageSender.send(phone, code);
     }
 
-    public boolean verify(String phone, String code) {
-        String savedCode = certificationCodeService.getCertificationCode(phone);
+    public void certificationBusiness(String email) {
+        String code = certificationCodeService.generateCertificationCode(email);
+        mailMessageSender.send(email, code);
+    }
+
+    public boolean verify(String identifier, String code) {
+        String savedCode = certificationCodeService.getCertificationCode(identifier);
 
         if (!ObjectUtils.nullSafeEquals(savedCode, code)) {
             throw new CustomException(ErrorCode.INVALID_CERTIFICATION_CODE);
         }
 
-        certificationCodeService.deleteCertificationCode(phone);
+        certificationCodeService.deleteCertificationCode(identifier);
         return true;
     }
 

--- a/src/main/java/net/mediger/auth/service/AuthService.java
+++ b/src/main/java/net/mediger/auth/service/AuthService.java
@@ -59,7 +59,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void join(RequestJoin requestJoin) {
+    public Long join(RequestJoin requestJoin) {
         isCheckedAccount(requestJoin.account());
         String encodedPassword = passwordEncoder.encode(requestJoin.password());
 
@@ -67,10 +67,11 @@ public class AuthService {
                 requestJoin.email(), requestJoin.phone());
 
         memberRepository.save(newMember);
+        return newMember.getId();
     }
 
     @Transactional
-    public void joinBusiness(RequestBusinessJoin requestBusinessJoin) {
+    public Long joinBusiness(RequestBusinessJoin requestBusinessJoin) {
         isCheckedAccount(requestBusinessJoin.account());
         String encodedPassword = passwordEncoder.encode(requestBusinessJoin.password());
 
@@ -79,6 +80,7 @@ public class AuthService {
                 requestBusinessJoin.startDate(), requestBusinessJoin.ownerName(), requestBusinessJoin.companyName());
 
         businessRepository.save(business);
+        return business.getId();
     }
 
     @Transactional

--- a/src/main/java/net/mediger/auth/service/CertificationCodeService.java
+++ b/src/main/java/net/mediger/auth/service/CertificationCodeService.java
@@ -1,0 +1,28 @@
+package net.mediger.auth.service;
+
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import net.mediger.auth.jwt.redis.RedisService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CertificationCodeService {
+
+    private final RedisService redisService;
+
+    public String generateCertificationCode(String phone) {
+//        String code = String.format("%04d", new Random().nextInt(1000000));
+        String code = "0000";
+        redisService.saveCertificationCode(phone, code);
+        return code;
+    }
+
+    public String getCertificationCode(String phone) {
+        return redisService.getCertificationCode(phone);
+    }
+
+    public void deleteCertificationCode(String phone) {
+        redisService.deleteCertificationCode(phone);
+    }
+}

--- a/src/main/java/net/mediger/auth/service/CertificationCodeService.java
+++ b/src/main/java/net/mediger/auth/service/CertificationCodeService.java
@@ -11,18 +11,18 @@ public class CertificationCodeService {
 
     private final RedisService redisService;
 
-    public String generateCertificationCode(String phone) {
+    public String generateCertificationCode(String identifier) {
 //        String code = String.format("%04d", new Random().nextInt(1000000));
         String code = "0000";
-        redisService.saveCertificationCode(phone, code);
+        redisService.saveCertificationCode(identifier, code);
         return code;
     }
 
-    public String getCertificationCode(String phone) {
-        return redisService.getCertificationCode(phone);
+    public String getCertificationCode(String identifier) {
+        return redisService.getCertificationCode(identifier);
     }
 
-    public void deleteCertificationCode(String phone) {
-        redisService.deleteCertificationCode(phone);
+    public void deleteCertificationCode(String identifier) {
+        redisService.deleteCertificationCode(identifier);
     }
 }

--- a/src/main/java/net/mediger/global/config/RedisConfig.java
+++ b/src/main/java/net/mediger/global/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package net.mediger.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/net/mediger/global/exception/ErrorCode.java
+++ b/src/main/java/net/mediger/global/exception/ErrorCode.java
@@ -37,7 +37,9 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
 
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    FAILED_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/net/mediger/global/exception/ErrorCode.java
+++ b/src/main/java/net/mediger/global/exception/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
 
     NOT_MATCH_USER(HttpStatus.BAD_REQUEST, "본인의 정보만 수정할 수 있습니다."),
 
+    INVALID_CERTIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
+
     NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 아이디입니다."),
     NOT_FOUND_AGE_RANGE(HttpStatus.NOT_FOUND, "존재하지 않는 연령대 입니다."),
     NOT_FOUND_HEALTH_CONDITIONS(HttpStatus.NOT_FOUND, "존재하지 않는 건강 상태 입니다."),

--- a/src/main/java/net/mediger/global/exception/response/ApiResponse.java
+++ b/src/main/java/net/mediger/global/exception/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package net.mediger.global.exception.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
     private HttpStatus status;
@@ -21,8 +23,8 @@ public class ApiResponse<T> {
         return new ApiResponse<>(HttpStatus.OK, HttpStatus.OK.value(), null, data);
     }
 
-    public static ApiResponse<Void> successWithNoContent() {
-        return new ApiResponse<>(HttpStatus.NO_CONTENT, HttpStatus.NO_CONTENT.value(), null, null);
+    public static ApiResponse<Void> success(HttpStatus status) {
+        return new ApiResponse<>(status, status.value(), null, null);
     }
 
     public static <T> ApiResponse<T> error(ErrorCode errorCode) {

--- a/src/main/java/net/mediger/global/message/MailMessageSender.java
+++ b/src/main/java/net/mediger/global/message/MailMessageSender.java
@@ -1,0 +1,33 @@
+package net.mediger.global.message;
+
+import lombok.RequiredArgsConstructor;
+import net.mediger.global.exception.CustomException;
+import net.mediger.global.exception.ErrorCode;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailMessageSender implements MessageSender {
+
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void send(String to, String message) {
+
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+
+        mailMessage.setTo(to);
+        mailMessage.setSubject("Mediger 인증 메일입니다.");
+        mailMessage.setText("인증번호 : " + message);
+
+        try {
+            mailSender.send(mailMessage);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FAILED_SEND_MAIL);
+        }
+
+        mailMessage.getText();
+    }
+}

--- a/src/main/java/net/mediger/global/message/MessageSender.java
+++ b/src/main/java/net/mediger/global/message/MessageSender.java
@@ -1,5 +1,5 @@
 package net.mediger.global.message;
 
 public interface MessageSender {
-        void send(String to, String title, String message);
+        void send(String to, String message);
 }

--- a/src/main/java/net/mediger/global/message/MessageSender.java
+++ b/src/main/java/net/mediger/global/message/MessageSender.java
@@ -1,0 +1,5 @@
+package net.mediger.global.message;
+
+public interface MessageSender {
+        void send(String to, String title, String message);
+}

--- a/src/main/java/net/mediger/global/message/SMSMessageSender.java
+++ b/src/main/java/net/mediger/global/message/SMSMessageSender.java
@@ -1,0 +1,43 @@
+package net.mediger.global.message;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SMSMessageSender implements MessageSender {
+
+    @Value("${coolsms.api.sender}")
+    private String senderNumber;
+
+    @Value("${coolsms.api.key}")
+    private String apiKey;
+
+    @Value("${coolsms.api.secret}")
+    private String apiSecret;
+
+    DefaultMessageService messageService;
+
+    @PostConstruct
+    public void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+    @Override
+    public void send(String to, String title, String message) {
+        Message msg = new Message();
+        msg.setFrom(senderNumber);
+        msg.setTo(to);
+        msg.setText("[" + title + "]\n\n" + message);
+
+//        messageService.sendOne(new SingleMessageSendingRequest(msg));
+        log.info("SMS Send to : {} Message : {} {}", to, title, message);
+    }
+}

--- a/src/main/java/net/mediger/global/message/SMSMessageSender.java
+++ b/src/main/java/net/mediger/global/message/SMSMessageSender.java
@@ -31,13 +31,14 @@ public class SMSMessageSender implements MessageSender {
     }
 
     @Override
-    public void send(String to, String title, String message) {
+    public void send(String to, String message) {
         Message msg = new Message();
+
         msg.setFrom(senderNumber);
         msg.setTo(to);
-        msg.setText("[" + title + "]\n\n" + message);
+        msg.setText("[ Mediger 인증 번호 ]\n\n" + message);
 
 //        messageService.sendOne(new SingleMessageSendingRequest(msg));
-        log.info("SMS Send to : {} Message : {} {}", to, title, message);
+        log.info("SMS Send to : {} Message : {}", to, message);
     }
 }

--- a/src/main/java/net/mediger/member/api/MemberController.java
+++ b/src/main/java/net/mediger/member/api/MemberController.java
@@ -9,6 +9,7 @@ import net.mediger.member.api.docs.MemberApiDocs;
 import net.mediger.member.api.dto.RequestBusinessDetails;
 import net.mediger.member.api.dto.RequestDetails;
 import net.mediger.member.service.MemberService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,7 +30,7 @@ public class MemberController implements MemberApiDocs {
         checkOwner(principal, id);
         memberService.updateDetails(id, requestDetails);
 
-        return ApiResponse.successWithNoContent();
+        return ApiResponse.success(HttpStatus.NO_CONTENT);
     }
 
     @Override
@@ -39,7 +40,7 @@ public class MemberController implements MemberApiDocs {
         checkOwner(principal, id);
         memberService.updateBusinessDetails(id, requestDetails);
 
-        return ApiResponse.successWithNoContent();
+        return ApiResponse.success(HttpStatus.NO_CONTENT);
     }
 
     private void checkOwner(Principal principal, Long id) {

--- a/src/main/java/net/mediger/member/domain/Business.java
+++ b/src/main/java/net/mediger/member/domain/Business.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,7 +39,7 @@ public class Business extends BaseTimeEntity {
     private String registrationNumber;
 
     @Column(nullable = false)
-    private LocalDate startDate;
+    private String startDate;
 
     @Column(nullable = false)
     private String ownerName;
@@ -66,7 +65,7 @@ public class Business extends BaseTimeEntity {
 
     @Builder(access = lombok.AccessLevel.PRIVATE)
     private Business(String account, String password, String name, String email, String registrationNumber,
-                     LocalDate startDate, String ownerName, String companyName,
+                     String startDate, String ownerName, String companyName,
                      String businessAddress,
                      String ecommerceRegistrationNumber, String settlementAccount, String documents, Role role) {
         this.account = account;
@@ -85,7 +84,7 @@ public class Business extends BaseTimeEntity {
     }
 
     public static Business createBusiness(String account, String password, String name, String email,
-            String registrationNumber, LocalDate startDate, String ownerName,
+            String registrationNumber, String startDate, String ownerName,
                                           String companyName) {
         return Business.builder()
                 .account(account)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,18 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 security:
   whiteList: ${WHITE_LIST}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,12 @@ jwt:
   access-token-expiration: ${ACCESS_TOKEN_EXPIRATION}
   refresh-token-expiration: ${REFRESH_TOKEN_EXPIRATION}
 
+coolsms:
+  api:
+    key: ${COOLSMS_API_KEY}
+    secret: ${COOLSMS_API_SECRET}
+    sender: ${COOLSMS_SENDER}
+
 logging:
   level:
     org:


### PR DESCRIPTION
### 📄 내용
- #17 
- 일반 회원은 휴대폰 번호 인증을 기업 회원은 이메일 인증을 진행합니다.

> SMS 전송 서비스는 개발 단계에서의 비용을 절감하기 위해 임시 번호로 대체하여 사용하기로 결정하였습니다. 
완성 후에는 정상적으로 SMS 인증이 사용 가능합니다.

### 👾 수정 사항
- 기존에는 회원가입 후에 아무것도 반환하지 않았습니다. 그러나 추가 정보를 위해 ID가 필요하다는 것을 놓쳐 회원가입 후 생성된 사용자의 ID를 헤더에 포함하여 응답하게 수정하였습니다.
