### PR TITLE
응답 형식 & 회원가입/로그인 로직 수정

### DIFF
--- a/src/main/java/net/mediger/auth/api/AuthController.java
+++ b/src/main/java/net/mediger/auth/api/AuthController.java
@@ -1,6 +1,5 @@
 package net.mediger.auth.api;
 
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import net.mediger.auth.api.docs.AuthApiDocs;
 import net.mediger.auth.api.dto.RequestBusinessJoin;
@@ -11,7 +10,6 @@ import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.auth.service.AuthService;
 import net.mediger.global.exception.response.ApiResponse;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,24 +53,14 @@ public class AuthController implements AuthApiDocs {
 
     @Override
     @PostMapping("join")
-    public ResponseEntity<ApiResponse<Void>> join(@RequestBody RequestJoin requestJoin) {
-        Long memberId = authService.join(requestJoin);
-
-        URI location = URI.create("/api/member/" + memberId);
-
-        return ResponseEntity.created(location)
-                .body(ApiResponse.success(HttpStatus.CREATED));
+    public ApiResponse<ResponseToken> join(@RequestBody RequestJoin requestJoin) {
+        return ApiResponse.success(authService.join(requestJoin));
     }
 
     @Override
     @PostMapping("join/business")
-    public ResponseEntity<ApiResponse<Void>> joinBusiness(@RequestBody RequestBusinessJoin requestBusinessJoin) {
-        Long businessId = authService.joinBusiness(requestBusinessJoin);
-
-        URI location = URI.create("/api/member/business/" + businessId);
-
-        return ResponseEntity.created(location)
-                .body(ApiResponse.success(HttpStatus.CREATED));
+    public ApiResponse<ResponseToken> joinBusiness(@RequestBody RequestBusinessJoin requestBusinessJoin) {
+        return ApiResponse.success(authService.joinBusiness(requestBusinessJoin));
     }
 
     @Override

--- a/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
+++ b/src/main/java/net/mediger/auth/api/docs/AuthApiDocs.java
@@ -9,7 +9,6 @@ import net.mediger.auth.api.dto.RequestLogin;
 import net.mediger.auth.api.dto.RequestVerify;
 import net.mediger.auth.jwt.ResponseToken;
 import net.mediger.global.exception.response.ApiResponse;
-import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Auth Controller", description = "회원가입/로그인 API")
 public interface AuthApiDocs {
@@ -44,17 +43,17 @@ public interface AuthApiDocs {
 
     @Operation(summary = "일반 회원 가입")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 오류")
     })
-    ResponseEntity<ApiResponse<Void>> join(RequestJoin requestJoin);
+    ApiResponse<ResponseToken> join(RequestJoin requestJoin);
 
     @Operation(summary = "사업자 회원 가입")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 오류")
     })
-    ResponseEntity<ApiResponse<Void>> joinBusiness(RequestBusinessJoin requestBusinessJoin);
+    ApiResponse<ResponseToken> joinBusiness(RequestBusinessJoin requestBusinessJoin);
 
     @Operation(summary = "일반 회원 로그인")
     @ApiResponses(value = {

--- a/src/main/java/net/mediger/auth/service/AuthService.java
+++ b/src/main/java/net/mediger/auth/service/AuthService.java
@@ -66,19 +66,20 @@ public class AuthService {
     }
 
     @Transactional
-    public Long join(RequestJoin requestJoin) {
+    public ResponseToken join(RequestJoin requestJoin) {
         isCheckedAccount(requestJoin.account());
         String encodedPassword = passwordEncoder.encode(requestJoin.password());
 
-        Member newMember = Member.createMember(requestJoin.account(), encodedPassword, requestJoin.name(),
+        Member member = Member.createMember(requestJoin.account(), encodedPassword, requestJoin.name(),
                 requestJoin.email(), requestJoin.phone());
 
-        memberRepository.save(newMember);
-        return newMember.getId();
+        memberRepository.save(member);
+
+        return login(new RequestLogin(requestJoin.account(), requestJoin.password()));
     }
 
     @Transactional
-    public Long joinBusiness(RequestBusinessJoin requestBusinessJoin) {
+    public ResponseToken joinBusiness(RequestBusinessJoin requestBusinessJoin) {
         isCheckedAccount(requestBusinessJoin.account());
         String encodedPassword = passwordEncoder.encode(requestBusinessJoin.password());
 
@@ -87,7 +88,8 @@ public class AuthService {
                 requestBusinessJoin.startDate(), requestBusinessJoin.ownerName(), requestBusinessJoin.companyName());
 
         businessRepository.save(business);
-        return business.getId();
+
+        return loginBusiness(new RequestLogin(requestBusinessJoin.account(), requestBusinessJoin.password()));
     }
 
     @Transactional

--- a/src/main/java/net/mediger/auth/service/CertificationCodeService.java
+++ b/src/main/java/net/mediger/auth/service/CertificationCodeService.java
@@ -1,6 +1,5 @@
 package net.mediger.auth.service;
 
-import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import net.mediger.auth.jwt.redis.RedisService;
 import org.springframework.stereotype.Service;

--- a/src/main/java/net/mediger/global/exception/ErrorCode.java
+++ b/src/main/java/net/mediger/global/exception/ErrorCode.java
@@ -8,39 +8,40 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
-    NULL_ACCOUNT(HttpStatus.BAD_REQUEST, "아이디는 필수로 입력해야 합니다."),
-    INVALID_ACCOUNT(HttpStatus.BAD_REQUEST, "아이디의 형식이 올바르지 않습니다. (영문 8자 이상)"),
+    NULL_ACCOUNT(HttpStatus.BAD_REQUEST, "VA001", "아이디는 필수로 입력해야 합니다."),
+    EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "VA002", "이미 존재하는 아이디입니다."),
+    INVALID_ACCOUNT(HttpStatus.BAD_REQUEST, "VA003", "아이디의 형식이 올바르지 않습니다. (영문 8자 이상)"),
 
-    NULL_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 필수로 입력해야 합니다."),
-    MISMATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호의 형식이 올바르지 않습니다. (영문, 숫자, 특수문자 8자 이상)"),
+    NULL_PASSWORD(HttpStatus.BAD_REQUEST, "VA004", "비밀번호는 필수로 입력해야 합니다."),
+    MISMATCH_PASSWORD(HttpStatus.BAD_REQUEST, "VA005", "비밀번호가 일치하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "VA006", "비밀번호의 형식이 올바르지 않습니다. (영문, 숫자, 특수문자 8자 이상)"),
 
-    NULL_NAME(HttpStatus.BAD_REQUEST, "이름은 필수로 입력해야 합니다."),
+    NULL_NAME(HttpStatus.BAD_REQUEST, "VA007", "이름은 필수로 입력해야 합니다."),
 
-    NULL_EMAIL(HttpStatus.BAD_REQUEST, "이메일은 필수로 입력해야 합니다."),
-    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "이메일 형식(xxx@xxx.xx)이 올바르지 않습니다."),
+    NULL_EMAIL(HttpStatus.BAD_REQUEST, "VA008", "이메일은 필수로 입력해야 합니다."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "VA009", "이메일 형식(xxx@xxx.xx)이 올바르지 않습니다."),
 
-    NULL_PHONE(HttpStatus.BAD_REQUEST, "휴대폰 번호는 필수로 입력해야 합니다."),
-    INVALID_PHONE(HttpStatus.BAD_REQUEST, "휴대폰 번호의 형식(010xxxxxxxx)이 올바르지 않습니다."),
+    NULL_PHONE(HttpStatus.BAD_REQUEST, "VA010", "휴대폰 번호는 필수로 입력해야 합니다."),
+    INVALID_PHONE(HttpStatus.BAD_REQUEST, "VA011", "휴대폰 번호의 형식(010xxxxxxxx)이 올바르지 않습니다."),
 
-    NOT_MATCH_USER(HttpStatus.BAD_REQUEST, "본인의 정보만 수정할 수 있습니다."),
+    INVALID_CERTIFICATION_CODE(HttpStatus.BAD_REQUEST, "CF001", "인증번호가 일치하지 않습니다."),
 
-    INVALID_CERTIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
+    NOT_MATCH_USER(HttpStatus.BAD_REQUEST, "AU001", "본인의 정보만 수정할 수 있습니다."),
 
-    NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 아이디입니다."),
-    NOT_FOUND_AGE_RANGE(HttpStatus.NOT_FOUND, "존재하지 않는 연령대 입니다."),
-    NOT_FOUND_HEALTH_CONDITIONS(HttpStatus.NOT_FOUND, "존재하지 않는 건강 상태 입니다."),
-    NOT_FOUND_GENDER(HttpStatus.NOT_FOUND, "존재하지 않는 성별 입니다."),
+    NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, "NF001", "존재하지 않는 아이디입니다."),
+    NOT_FOUND_AGE_RANGE(HttpStatus.NOT_FOUND, "NF002", "존재하지 않는 연령대 입니다."),
+    NOT_FOUND_HEALTH_CONDITIONS(HttpStatus.NOT_FOUND, "NF003", "존재하지 않는 건강 상태 입니다."),
+    NOT_FOUND_GENDER(HttpStatus.NOT_FOUND, "NF004", "존재하지 않는 성별 입니다."),
 
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "UA001", "만료된 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "UA002", "유효하지 않은 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UA003", "인증이 필요합니다."),
 
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "FB001", "접근 권한이 없습니다."),
 
-    FAILED_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
+    FAILED_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "SE001", "이메일 전송에 실패했습니다.");
 
     private final HttpStatus status;
+    private final String codeName;
     private final String message;
 }

--- a/src/main/java/net/mediger/global/exception/response/ApiResponse.java
+++ b/src/main/java/net/mediger/global/exception/response/ApiResponse.java
@@ -16,18 +16,20 @@ public class ApiResponse<T> {
 
     private HttpStatus status;
     private int code;
+    private String codeName;
     private String message;
     private T data;
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(HttpStatus.OK, HttpStatus.OK.value(), null, data);
+        return new ApiResponse<>(HttpStatus.OK, HttpStatus.OK.value(), null, null, data);
     }
 
     public static ApiResponse<Void> success(HttpStatus status) {
-        return new ApiResponse<>(status, status.value(), null, null);
+        return new ApiResponse<>(status, status.value(), null, null, null);
     }
 
     public static <T> ApiResponse<T> error(ErrorCode errorCode) {
-        return new ApiResponse<>(errorCode.getStatus(), errorCode.getStatus().value(), errorCode.getMessage(), null);
+        return new ApiResponse<>(errorCode.getStatus(), errorCode.getStatus().value(), errorCode.getCodeName(),
+                errorCode.getMessage(), null);
     }
 }


### PR DESCRIPTION
## 내용
### #22 
#### 기존
```json
{
  "status": "BAD_REQUEST",
  "code": 400,
  "message": "아이디의 형식이 올바르지 않습니다. (영문 8자 이상)"
}
```

#### 수정 후
```json
{
  "status": "BAD_REQUEST",
  "code": 400,
  "codeName": "VA003"
  "message": "아이디의 형식이 올바르지 않습니다. (영문 8자 이상)"
}
```

### #23 
회원가입 후에 로그인을 직접해야 했습니다.
여러 레퍼런스를 찾아본 후 회원가입하고 나서 자동으로 로그인이 되는 것이 사용자의 편의성을 높일 수 있다고 생각하여 수정하게 되었습니다.